### PR TITLE
add middleware to keep id of trip object from being in body of requests

### DIFF
--- a/server/api/trips/index.js
+++ b/server/api/trips/index.js
@@ -7,7 +7,8 @@ const {
 const { 
         verifyJWT,
         verifyTripId,
-        verifyTrip
+        verifyTrip,
+        verifyNoTripId
       } = require('../../middleware/custom');
 
 
@@ -25,7 +26,7 @@ trips.get('/:tripId', verifyJWT, verifyTripId, (req, res) => {
         .catch(() => res.status(500).json({ error: 'There was an error getting the trip from the database' }));
 });
 
-trips.put('/:tripId', verifyJWT, verifyTripId, (req, res) => {
+trips.put('/:tripId', verifyJWT, verifyNoTripId, verifyTripId, (req, res) => {
     const tripId = req.params.tripId;
     const updates = req.body;
     Trips.update(updates, tripId)
@@ -54,7 +55,7 @@ trips.delete('/:tripId', verifyJWT, verifyTripId, (req, res) => {
         .catch(() => res.status(500).json({ error: 'There was an error deleting the trip from the database' }));
 });
 
-trips.post('/', verifyJWT, verifyTrip, (req, res) => {
+trips.post('/', verifyJWT, verifyNoTripId, verifyTrip, (req, res) => {
     const tripToAdd = {
         ...req.body,
         isPrivate: convertBooleanToNum(req.body.isPrivate),

--- a/server/middleware/custom/index.js
+++ b/server/middleware/custom/index.js
@@ -6,6 +6,7 @@ const verifyTrip = require('./verifyTrip');
 const verifyUser = require('./verifyUser');
 const verifyProfileUpdate = require('./verifyProfileUpdate');
 const verifyUserAccessToUsers = require('./verifyUserAccessToUsers');
+const verifyNoTripId = require('./verifyNoTripId');
 
 module.exports = {
     verifyUserRegInfo,
@@ -15,5 +16,6 @@ module.exports = {
     verifyTrip,
     verifyUser,
     verifyProfileUpdate,
-    verifyUserAccessToUsers
+    verifyUserAccessToUsers,
+    verifyNoTripId
 };

--- a/server/middleware/custom/verifyNoTripId.js
+++ b/server/middleware/custom/verifyNoTripId.js
@@ -1,0 +1,9 @@
+module.exports = (req, res, next) => {
+    const trip = req.body;
+    
+    if (trip.id) {
+        res.status(400).json({ error: 'The id property cannot be included in trip object' });
+    } else {
+        next();
+    };
+};


### PR DESCRIPTION
The `id` of a trip could be set in the request body for adding a new trip and updating an existing trip. I added validation that checks it isn't present in request body and if it is an error is returned instead of letting the request go through.